### PR TITLE
Updates to 3-Way Negotiation Task

### DIFF
--- a/projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+++ b/projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
@@ -15,7 +15,7 @@ But again, any combination of parties that decides to work together must agree o
 
 # Your Goal
 
-Your goal in these negotiations is to ensure that Organization A gets as much of the benefits as possible in the time allotted.  All representatives have received this same information and have been empowered to commit their organizations.  It is uncertain whether you will have any future dealings with the other parties.
+Your goal in these negotiations is to ensure that Organization A gets as much of the benefits as possible in the time allotted. All representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
 
 
 # Ground Rules

--- a/projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+++ b/projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
@@ -15,7 +15,7 @@ But again, any combination of parties that decides to work together must agree o
 
 # Your Goal
 
-Your goal in these negotiations is to ensure that Organization B gets as much of the benefits as possible in the time allotted.  All representatives have received this same information and have been empowered to commit their organizations.  It is uncertain whether you will have any future dealings with the other parties.
+Your goal in these negotiations is to ensure that Organization B gets as much of the benefits as possible in the time allotted. All representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
 
 
 # Ground Rules

--- a/projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+++ b/projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
@@ -15,7 +15,7 @@ But again, any combination of parties that decides to work together must agree o
 
 # Your Goal
 
-Your goal in these negotiations is to ensure that Organization C gets as much of the benefits as possible in the time allotted.  All representatives have received this same information and have been empowered to commit their organizations.  It is uncertain whether you will have any future dealings with the other parties.
+Your goal in these negotiations is to ensure that Organization C gets as much of the benefits as possible in the time allotted. All representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
 
 
 # Ground Rules

--- a/projects/3-way-negotiation/02_payoff_table.md
+++ b/projects/3-way-negotiation/02_payoff_table.md
@@ -7,7 +7,7 @@ notes: Shared table of payoffs
 # Schedule of Benefits
 
 | Parties                        |  Amount  |
-| ------------------------------ | -------- |
+| :----------------------------- | -------: |
 | A alone gets                   | 0        |
 | B alone gets                   | 0        |
 | C alone gets                   | 0        |

--- a/projects/3-way-negotiation/03_initial_instructions.md
+++ b/projects/3-way-negotiation/03_initial_instructions.md
@@ -1,0 +1,11 @@
+---
+name: projects/3-way-negotiation/03_initial_instructions.md
+type: noResponse
+Notes: Reminder Instructions to Player A
+---
+
+# Introduce yourself and your organization!
+
+As you get started in this negotiation, please go around the room and share the organization you represent.
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
@@ -1,0 +1,11 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
+type: noResponse
+notes: Set-up for the reading comprehension questions
+---
+
+# Below are the answers to the four reading comprehension questions.
+
+Please make sure you read them carefully in order to understand why they are correct --- these details will be very important for the main negotiation!
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
@@ -6,6 +6,6 @@ notes: Set-up for the reading comprehension questions
 
 # Below are the answers to the four reading comprehension questions.
 
-Please make sure you read them carefully in order to understand why they are correct --- these details will be very important for the main negotiation!
+Please make sure you read them carefully in order to understand why they are correct -- these details will be very important for the main negotiation!
 
 ---

--- a/projects/3-way-negotiation/04_readingcomprehension_01setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_01setup.md
@@ -4,10 +4,10 @@ type: noResponse
 notes: Set-up for the reading comprehension questions
 ---
 
-# Please answer the following questions.
+# Please answer the following question (Question 1 of 4).
 
-Before you proceed to the main negotiation, we want to make sure you fully understand the rules. Please answer the following four questions about the instructions you just read.
+Before you proceed to the main negotiation, we want to make sure you fully understand the rules. You will be asked to answer four questions about the instructions you just read. The first of these questions is on this page.
 
-To help remind you of the instructions, they are displayed again at the bottom of this page (below the questions).
+To help remind you of the instructions, they are displayed again at the bottom of this page (below the question).
 
 ---

--- a/projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
@@ -8,6 +8,6 @@ notes: Set-up for all four reading comprehension questions
 
 Before you proceed to the main negotiation, we want to make sure you fully understand the rules. Please answer the following four questions about the instructions you just read.
 
-To help remind you of the instructions, they are displayed again at the bottom of this page (below the question).
+To help remind you of the instructions, they are displayed again at the bottom of this page (below the four questions).
 
 ---

--- a/projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
@@ -1,0 +1,13 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
+type: noResponse
+notes: Set-up for all four reading comprehension questions
+---
+
+# Please answer the following four questions.
+
+Before you proceed to the main negotiation, we want to make sure you fully understand the rules. Please answer the following four questions about the instructions you just read.
+
+To help remind you of the instructions, they are displayed again at the bottom of this page (below the question).
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_02setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_02setup.md
@@ -1,0 +1,9 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_02setup.md
+type: noResponse
+notes: Set-up for the reading comprehension questions (q2)
+---
+
+# Please answer the following question (Question 2 of 4).
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_03setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_03setup.md
@@ -1,0 +1,9 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_03setup.md
+type: noResponse
+notes: Set-up for the reading comprehension questions (q3)
+---
+
+# Please answer the following question (Question 3 of 4).
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_04setup.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_04setup.md
@@ -1,0 +1,9 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_04setup.md
+type: noResponse
+notes: Set-up for the reading comprehension questions (q4)
+---
+
+# Please answer the following question (Question 4 of 4).
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_q01.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q01.md
@@ -1,6 +1,7 @@
 ---
 name: projects/3-way-negotiation/04_readingcomprehension_q01.md
 type: openResponse
+rows: 1
 author: Xinlan Emily Hu
 modified: August 22, 2023
 ---

--- a/projects/3-way-negotiation/04_readingcomprehension_q01.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q01.md
@@ -6,7 +6,7 @@ author: Xinlan Emily Hu
 modified: August 22, 2023
 ---
 
-If Organizations A, B, and C accept a three-way deal, how many points would they share?
+#### (Q1) If Organizations A, B, and C accept a three-way deal, how many points would they share?
 
 ---
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the first reading comprehension question
 ---
 
-## Answer: 121.
+## Answer to Q1: 121.
 
 A three-way deal between A, B, and C would result in a sharing a total of 121 points.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the first reading comprehension question
 ---
 
-# Answer: 121.
+## Answer: 121.
 
 A three-way deal between A, B, and C would result in a sharing a total of 121 points.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
@@ -1,0 +1,11 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+type: noResponse
+notes: Answer to the first reading comprehension question
+---
+
+# Answer: 121.
+
+A three-way deal between A, B, and C would result in a sharing a total of 121 points.
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_q02.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q02.md
@@ -5,7 +5,7 @@ author: Xinlan Emily Hu
 modified: August 22, 2023
 ---
 
-If two of the three parties reach an agreement, how many parties must accept the deal in order for it to be valid?
+How many parties must accept a deal in order for it to be valid?
 
 ---
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q02.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q02.md
@@ -5,7 +5,7 @@ author: Xinlan Emily Hu
 modified: August 22, 2023
 ---
 
-How many parties must accept a deal in order for it to be valid?
+#### (Q2) How many parties must accept a deal in order for it to be valid?
 
 ---
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
@@ -1,0 +1,11 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+type: noResponse
+notes: Answer to the second reading comprehension question
+---
+
+# Answer: 2.
+
+Only *two* out of the three parties need to accept a deal in order for it to be valid.
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the second reading comprehension question
 ---
 
-## Answer: 2.
+## Answer to Q2: 2.
 
 Only *two* out of the three parties need to accept a deal in order for it to be valid.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the second reading comprehension question
 ---
 
-# Answer: 2.
+## Answer: 2.
 
 Only *two* out of the three parties need to accept a deal in order for it to be valid.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q03.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q03.md
@@ -6,7 +6,7 @@ author: Xinlan Emily Hu
 modified: August 22, 2023
 ---
 
-Please examine the Schedule of Benefits. How many MORE points does a deal between A and B generate, compared to a deal between A and C?
+#### (Q3) Please examine the Schedule of Benefits. How many MORE points does a deal between A and B generate, compared to a deal between A and C?
 
 ---
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q03.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q03.md
@@ -1,6 +1,7 @@
 ---
 name: projects/3-way-negotiation/04_readingcomprehension_q03.md
 type: openResponse
+rows: 1
 author: Xinlan Emily Hu
 modified: August 22, 2023
 ---

--- a/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
@@ -1,0 +1,13 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+type: noResponse
+notes: Answer to the third reading comprehension question
+---
+
+# Answer: 34.
+
+According to the Schedule of Benefits, a deal between A and B generates 118 points. A deal between A and C generates 84 points. Therefore, 118-84 = 34.
+
+Pay close attention to the different numbers of points that different combinations of the organizations can generate. This may affect how you approach the negotiation!
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the third reading comprehension question
 ---
 
-# Answer: 34.
+## Answer: 34.
 
 According to the Schedule of Benefits, a deal between A and B generates 118 points. A deal between A and C generates 84 points. Therefore, 118-84 = 34.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the third reading comprehension question
 ---
 
-## Answer: 34.
+## Answer to Q3: 34.
 
 According to the Schedule of Benefits, a deal between A and B generates 118 points. A deal between A and C generates 84 points. Therefore, 118-84 = 34.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q04.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q04.md
@@ -5,7 +5,7 @@ author: Xinlan Emily Hu
 modified: August 22, 2023
 ---
 
-What is your MAIN goal in this negotiation?
+#### (Q4) What is your MAIN goal in this negotiation?
 
 ---
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
@@ -1,0 +1,12 @@
+---
+name: projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
+type: noResponse
+notes: Answer to the fourth reading comprehension question
+---
+
+# Answer: Maximize the benefits that MY organization can earn.
+
+Your goal in this negotiation is to *get as many points as possible for your organization*. Recall from the instructions that all representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
+
+
+---

--- a/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the fourth reading comprehension question
 ---
 
-## Answer: Maximize the benefits that MY organization can earn.
+## Answer to Q4: Maximize the benefits that MY organization can earn.
 
 Your goal in this negotiation is to *get as many points as possible for your organization*. Recall from the instructions that all representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
 

--- a/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
+++ b/projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
@@ -4,7 +4,7 @@ type: noResponse
 notes: Answer to the fourth reading comprehension question
 ---
 
-# Answer: Maximize the benefits that MY organization can earn.
+## Answer: Maximize the benefits that MY organization can earn.
 
 Your goal in this negotiation is to *get as many points as possible for your organization*. Recall from the instructions that all representatives have received the same information and have been empowered to commit to agreements on behalf of their organizations. It is uncertain whether you will have any future dealings with the other parties.
 

--- a/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
+++ b/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
@@ -25,12 +25,13 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
-      - name: Reading Comprehension
-        duration: 180
-        desc: Check that participants understand the rules.
+      - name: Reading Comprehension Question 1
+        duration: 30
+        desc: First of four reading comprehension questions
         elements:
           - projects/3-way-negotiation/04_readingcomprehension_01setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q01.md
+          - type: separator
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
             file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
@@ -47,11 +48,20 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 1 (Answer)
+        duration: 30
+        desc: Answer to first of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 2
+        duration: 30
+        desc: Second of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_02setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q02.md
+          - type: separator
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
             file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
@@ -68,11 +78,20 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 2 (Answer)
+        duration: 30
+        desc: Second of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 3
+        duration: 30
+        desc: Third of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_03setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q03.md
+          - type: separator
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
             file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
@@ -89,11 +108,20 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 3 (Answer)
+        duration: 30
+        desc: Answer to third of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
           - type: submitButton
 
+      - name: Reading Comprehension Question 4
+        duration: 30
+        desc: Last of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_04setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q04.md
+          - type: separator
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
             file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
@@ -110,6 +138,10 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
           
+      - name: Reading Comprehension Question 4 (Answer)
+        duration: 30
+        desc: Answer to last of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
           - type: submitButton
 

--- a/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
+++ b/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
@@ -68,6 +68,9 @@ treatments:
         chatType: text
         elements: 
           - type: prompt
+            file: projects/3-way-negotiation/03_initial_instructions.md
+            hideTime: 30
+          - type: prompt
             file: projects/3-way-negotiation/03a_rep_a.md
             showToPositions:
               - 0

--- a/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
+++ b/projects/3-way-negotiation/treatments.3_way_negotiation.yaml
@@ -22,7 +22,7 @@ treatments:
             file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
             showToPositions:
               - 2
-          - projects/3-way-negotiation/02_payoff_table_img.md
+          - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
       - name: Reading Comprehension
@@ -31,8 +31,68 @@ treatments:
         elements:
           - projects/3-way-negotiation/04_readingcomprehension_01setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q01.md
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_02setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q02.md
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_03setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q03.md
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+          - type: submitButton
+
+          - projects/3-way-negotiation/04_readingcomprehension_04setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q04.md
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
@@ -47,7 +107,10 @@ treatments:
             file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
             showToPositions:
               - 2
-          - projects/3-way-negotiation/02_payoff_table_img.md
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+          
+          - projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
           - type: submitButton
 
       - name: Main Discussion
@@ -68,7 +131,7 @@ treatments:
             showToPositions:
               - 2
           - projects/3-way-negotiation/04_instructions_3_way_negotation_in_round.md
-          - projects/3-way-negotiation/02_payoff_table_img.md
+          - projects/3-way-negotiation/02_payoff_table.md
 
       - name: Post-Survey (Submission of Deal Sheet)
         duration: 60

--- a/projects/3-way-negotiation/treatments.3_way_negotiation_separate_RC.yaml
+++ b/projects/3-way-negotiation/treatments.3_way_negotiation_separate_RC.yaml
@@ -25,15 +25,12 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
-      - name: Reading Comprehension Questions
-        duration: 180
-        desc: Present four reading comprehension questions
+      - name: Reading Comprehension Question 1
+        duration: 30
+        desc: First of four reading comprehension questions
         elements:
-          - projects/3-way-negotiation/04_readingcomprehension_01setup_general.md
+          - projects/3-way-negotiation/04_readingcomprehension_01setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q01.md
-          - projects/3-way-negotiation/04_readingcomprehension_q02.md
-          - projects/3-way-negotiation/04_readingcomprehension_q03.md
-          - projects/3-way-negotiation/04_readingcomprehension_q04.md
           - type: separator
           - projects/3-way-negotiation/01_repeated_instructions_header.md
           - type: prompt
@@ -51,14 +48,100 @@ treatments:
           - projects/3-way-negotiation/02_payoff_table.md
           - type: submitButton
 
-      - name: Reading Comprehension (Answers)
-        duration: 60
-        desc: Answers to reading comprehension questions
+      - name: Reading Comprehension Question 1 (Answer)
+        duration: 30
+        desc: Answer to first of four reading comprehension questions
         elements:
-          - projects/3-way-negotiation/04_readingcomprehension_01answer_setup.md
           - projects/3-way-negotiation/04_readingcomprehension_q01_answer.md
+          - type: submitButton
+
+      - name: Reading Comprehension Question 2
+        duration: 30
+        desc: Second of four reading comprehension questions
+        elements:
+          - projects/3-way-negotiation/04_readingcomprehension_02setup.md
+          - projects/3-way-negotiation/04_readingcomprehension_q02.md
+          - type: separator
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+
+      - name: Reading Comprehension Question 2 (Answer)
+        duration: 30
+        desc: Second of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q02_answer.md
+          - type: submitButton
+
+      - name: Reading Comprehension Question 3
+        duration: 30
+        desc: Third of four reading comprehension questions
+        elements:
+          - projects/3-way-negotiation/04_readingcomprehension_03setup.md
+          - projects/3-way-negotiation/04_readingcomprehension_q03.md
+          - type: separator
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+
+      - name: Reading Comprehension Question 3 (Answer)
+        duration: 30
+        desc: Answer to third of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q03_answer.md
+          - type: submitButton
+
+      - name: Reading Comprehension Question 4
+        duration: 30
+        desc: Last of four reading comprehension questions
+        elements:
+          - projects/3-way-negotiation/04_readingcomprehension_04setup.md
+          - projects/3-way-negotiation/04_readingcomprehension_q04.md
+          - type: separator
+          - projects/3-way-negotiation/01_repeated_instructions_header.md
+          - type: prompt
+            file: projects/3-way-negotiation/01a_instructions_3_way_negotiation.md
+            showToPositions:
+              - 0
+          - type: prompt
+            file: projects/3-way-negotiation/01b_instructions_3_way_negotiation.md
+            showToPositions:
+              - 1
+          - type: prompt
+            file: projects/3-way-negotiation/01c_instructions_3_way_negotiation.md
+            showToPositions:
+              - 2
+          - projects/3-way-negotiation/02_payoff_table.md
+          - type: submitButton
+          
+      - name: Reading Comprehension Question 4 (Answer)
+        duration: 30
+        desc: Answer to last of four reading comprehension questions
+        elements:
           - projects/3-way-negotiation/04_readingcomprehension_q04_answer.md
           - type: submitButton
 


### PR DESCRIPTION
# Changes
- Update wording on instructions
- Add pages explaining the correct answers after every reading comprehension question
- Change the reading comprehension flow to: {(1) Ask one question at a time (2) Show the answer to the question} x 4 questions

# Remaining To Do's
- Test to make sure everything looks good (currently blocked: https://github.com/Watts-Lab/deliberation-empirica/issues/607)
- See if it's possible to make the "Submit" button on the reading comprehension questions show up only AFTER you submit something (even if it's not possible to validate the answer, we should force people to have a response and not show a 'next' button until they do).
- Check/play around with timing for the deliberation
- (Low priority) the reading comprehension section on the YAML gets a bit long and unweildy!