### PR TITLE
Updates based on 5/20 Pilot

### DIFF
--- a/projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
@@ -1,0 +1,8 @@
+---
+name: projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
+type: noResponse
+---
+
+# ❗ 1 minute warning! Please say goodbye to your partner.
+
+---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
@@ -3,6 +3,6 @@ name: projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warn
 type: noResponse
 ---
 
-# ❗ 1 minute warning! Please say goodbye to your partner.
+# ❗ 1 minute warning! Time to say goodbye.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/in_round_5min_warning.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/in_round_5min_warning.md
@@ -1,0 +1,8 @@
+---
+name: projects/constructive_disagreement/super_sabbatical_wbl/in_round_5min_warning.md
+type: noResponse
+---
+
+# ⏰ 5 minute warning! Please wrap up your discussion. 
+
+---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/in_round_leave_early.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/in_round_leave_early.md
@@ -3,8 +3,6 @@ name: projects/constructive_disagreement/super_sabbatical_wbl/in_round_leave_ear
 type: noResponse
 ---
 
-If you are all done with the negotiation, you have the option to leave the negotiation early. A "Leave Negotiation Early" button will appear below if you have jotted down enough notes.
-
-Please make sure that you write down everything you need about the deal before leaving the room. **Once you choose to leave early, you will NOT be able to return.**
+_Please make sure that you write down everything you need about the deal before leaving the room. **Once you choose to leave early, you will NOT be able to return.**_
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/in_round_materials_reminder.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/in_round_materials_reminder.md
@@ -5,6 +5,6 @@ type: noResponse
 
 # Reading Materials Reminder
 
-If you need a reminder of the reading materials, please use the radio buttons below to review information about this negotiation.
+If you need a reminder of the reading materials, you can use the radio buttons below to display and hide them.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/maintask_done.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/maintask_done.md
@@ -1,0 +1,10 @@
+---
+name: projects/constructive_disagreement/super_sabbatical_wbl/maintask_done.md
+type: noResponse
+---
+
+# You are now done with the main activity. There are just a few questions to wrap up.
+
+The next few pages will contain some questions about your experience today. Please answer these questions as truthfully as you can, reflecting on how _you felt as a participant_ in today's discussion.
+
+---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
@@ -1,0 +1,8 @@
+---
+name: projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
+type: noResponse
+---
+
+_When you click Submit and Start Exercise, you will begin your **30-minute timed discussion.**_
+
+---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_preamble.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_preamble.md
@@ -5,7 +5,7 @@ type: noResponse
 
 # Please take a moment to write down your strategy for this negotiation.
 
-Studies have shown that negotiators tend to perform better when they plan beforehand! Thus, reflecting on your role and the information you have just reviewed, please take a moment to think about how you plan to achieve your goals in this negotiation.
+Studies have shown that negotiators tend to perform better when they plan beforehand! Thus, reflecting on your role and the information you have just reviewed, please take a moment to think about how you plan to achieve your goals in this negotiation. (_Everything you write here is just for your personal reference!_)
 
 You may want to consider:
 

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_provost.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_provost.md
@@ -32,6 +32,4 @@ Before you start your negotiation, here is a summary of the boundaries of your n
 - You **must retain** the star scientist or risk losing your own job.
 - You cannot authorize more than **6 months of paid sabbatical**. You can, however, offer longer sabbaticals of up to 24 months away.
 
-Now to negotiate...
-
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_provost_pep_talk.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_provost_pep_talk.md
@@ -5,14 +5,12 @@ type: noResponse
 
 # Key Things to Remember: Provost.
 
-At most universities, the Provost is the senior leader in charge of all things related to faculty, research, and teaching. Recruiting and retaining star faculty is a very important element of the job, but so is maintaining a health culture for the entire community.
+- In this negotiation, you must balance two competing objectives: (1) retaining a stellar faculty member, whose departure would threaten the department's prestige and may cost you your job; and (2) following the rules of the university, which are are necessary for maintaining the broader precedents and culture of the institution.
 
-To that end, you must not agree to any provision of a deal that would create an unsustainable precedent. Specifically, there are two things you cannot agree; either one will get you removed from your post.
+- The rules state that the maximum you can pay for 100% of the faculty member's patent pool is **$275,000**. All partial purchases should scale to this maximum; for a 40% share, for example, you cannot pay more than **$110K** ($275K \* 0.4).
 
-First, you cannot pay for more than **6 months** of sabbatical, though you can approve longer leave times. Departments routinely approve up to a year, and in rare cases the Provost allows longer leaves --- normally only to members of staff who are clearly stars in some way.
+- You also cannot pay for more than **6 months** of sabbatical (typically at a salary of $10,000 per month), though you can approve longer leave times (up to 24 months). Giving world-class scholars the freedom and flexibility to work at their best is very important to you and your institution.
 
-Second, you may not exceed the maximum authorized payment and / or valuation for the scientist’s IP. The maximum you can pay for their share of the lab patent pool is **$275K**, but because this is about managing risk, you should use that as the maximum valuation you can pay for any amount of their holdings. So for 40% of their share, you cannot pay more than **$110K** ($275K \* 0.4).
-
-Subject to avoiding these problems, you can offer a variety of other inducements to get your star back and in good condition, and that is your best outcome. If you cannot reach an agreement in which they return rested and happy to be back, not having them back will be a disappointment but still better than having them return feeling either still too tired to work or just not happy to be back.
+- **Feel free to get creative:** outside of the hard rules, you can offer a variety of other inducements to get your star scientist back to the university and ready to continue their productive work.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_provost_pep_talk.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_provost_pep_talk.md
@@ -6,11 +6,8 @@ type: noResponse
 # Key Things to Remember: Provost.
 
 - In this negotiation, you must balance two competing objectives: (1) retaining a stellar faculty member, whose departure would threaten the department's prestige and may cost you your job; and (2) following the rules of the university, which are are necessary for maintaining the broader precedents and culture of the institution.
-
 - The rules state that the maximum you can pay for 100% of the faculty member's patent pool is **$275,000**. All partial purchases should scale to this maximum; for a 40% share, for example, you cannot pay more than **$110K** ($275K \* 0.4).
-
 - You also cannot pay for more than **6 months** of sabbatical (typically at a salary of $10,000 per month), though you can approve longer leave times (up to 24 months). Giving world-class scholars the freedom and flexibility to work at their best is very important to you and your institution.
-
 - **Feel free to get creative:** outside of the hard rules, you can offer a variety of other inducements to get your star scientist back to the university and ready to continue their productive work.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist.md
@@ -32,6 +32,4 @@ Before you start your negotiation, here is a summary of the boundaries of your n
 - Additionally, you do NOT want to lose the 20% down payment on your boat. Since you have already sold your condo, you will need to secure a new place to live if you do not go on the trip.
 - To be able to accept the position at the Institute of Advanced Studies, you **must reach an agreement with the provost**, as private companies would be too risky and slow.
 
-Now to negotiate...
-
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
@@ -5,12 +5,12 @@ type: noResponse
 
 # Key Things to Remember: Star Scientist.
 
-After a very long period of overwork, the physical and emotional toll is such that, on your doctor’s orders, you need a long break. Your goal is to get 21 months away: 12 months of time off to decompress and sail in the Pacific, and 9 months of creative freedom to pursue new ideas in the Institute.
+- **You need a break:** After a very long period of overwork, the physical and emotional toll has caused your doctor to insist that you take time away. Your goal is to take **21 months** of sabbatical: 12 months of time off to decompress and sail in the Pacific, and 9 months of creative freedom to pursue new ideas in the Institute.
 
-You need at least **$355,000** in order to make this dream possible, **and you have already sold your condo and taken on significant financial commitments**. Your conversation with the Provost is the only way for you to complete the deal you have committed to and to begin your leave as soon as possible.
+- You need at least **$355,000** in order to make this dream possible: $260,000 for the boating trip, and $95,000 upon your return, as you need to find a new place to live, get a car, and restart your career.
 
-This makes your conversation with the Provost crucial. As you enter this conversation, remember that you are a high-profile scientist --- a _rising star_. You will be snatched up quickly if things do not work out with the Provost. In light of these facts, be as assertive as you can.
+- **You have already sold your condo and taken on significant financial commitments**. You need a deal _now_, or else you will lose your down payment and find yourself without a place to stay.
 
-This conversation is the best chance for you to get the $355K and secure both your financial and your physical well-being.
+- You are a high-profile scientist --- a **rising star**. You will be snatched up quickly if things do not work out with the Provost, and losing you will hurt the university. Use this as leverage, and feel **free to get creative**.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
@@ -6,11 +6,8 @@ type: noResponse
 # Key Things to Remember: Star Scientist.
 
 - **You need a break:** After a very long period of overwork, the physical and emotional toll has caused your doctor to insist that you take time away. Your goal is to take **21 months** of sabbatical: 12 months of time off to decompress and sail in the Pacific, and 9 months of creative freedom to pursue new ideas in the Institute.
-
 - You need at least **$355,000** in order to make this dream possible: $260,000 for the boating trip, and $95,000 upon your return, as you need to find a new place to live, get a car, and restart your career.
-
 - **You have already sold your condo and taken on significant financial commitments**. You need a deal _now_, or else you will lose your down payment and find yourself without a place to stay.
-
 - You are a high-profile scientist --- a **rising star**. You will be snatched up quickly if things do not work out with the Provost, and losing you will hurt the university. Use this as leverage, and feel **free to get creative**.
 
 ---

--- a/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
@@ -316,9 +316,6 @@ treatments:
             showToPositions: [1]
           - type: separator
             style: thin
-          - type: prompt
-            file: projects/constructive_disagreement/super_sabbatical_wbl/in_round_leave_early.md
-            displayTime: 600
           - type: submitButton
             name: submitDealSheet
             displayTime: 600
@@ -327,7 +324,15 @@ treatments:
               - promptName: inNegotiationNotes
                 comparator: lengthAtLeast
                 value: 10
-          - projects/constructive_disagreement/super_sabbatical_wbl/in_round_materials_reminder.md
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/in_round_leave_early.md
+            displayTime: 600
+            conditions:
+              - promptName: inNegotiationNotes
+                comparator: lengthAtLeast
+                value: 10
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/in_round_materials_reminder.md
           - type: prompt
             name: toggleRoleInstructions
             file: projects/constructive_disagreement/super_sabbatical_wbl/toggle_role_information.md

--- a/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
@@ -73,7 +73,7 @@ treatments:
           - type: submitButton
             buttonText: Continue
       - name: Key Things To Remember
-        duration: 120
+        duration: 90
         elements:
           - type: prompt
             file: projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
@@ -222,7 +222,63 @@ treatments:
                 comparator: exists
               - promptName: strategyPlan
                 comparator: exists
+          - projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
+            conditions:
+                - promptName: targetPrice
+                  comparator: exists
+                - promptName: strategyPlan
+                  comparator: exists
 
+          - type: separator
+            style: thin
+          - projects/constructive_disagreement/super_sabbatical_wbl/in_round_materials_reminder.md
+          - type: prompt
+            name: toggleRoleInstructions
+            file: projects/constructive_disagreement/super_sabbatical_wbl/toggle_role_information.md
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist.md
+            showToPositions:
+              - 0
+            conditions:
+              - promptName: toggleRoleInstructions
+                comparator: equals
+                value: "⬇️ Display Role Information"
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/role_provost.md
+            showToPositions:
+              - 1
+            conditions:
+              - promptName: toggleRoleInstructions
+                comparator: equals
+                value: "⬇️ Display Role Information"
+          - type: prompt
+            name: toggleRolePepTalk
+            file: projects/constructive_disagreement/super_sabbatical_wbl/toggle_role_pep_talk.md
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/role_star_scientist_pep_talk.md
+            showToPositions:
+              - 0
+            conditions:
+              - promptName: toggleRolePepTalk
+                comparator: equals
+                value: "⬇️ Display Key Things to Remember"
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/role_provost_pep_talk.md
+            showToPositions:
+              - 1
+            conditions:
+              - promptName: toggleRolePepTalk
+                comparator: equals
+                value: "⬇️ Display Key Things to Remember"
+          - type: prompt
+            name: toggleGeneralInformation
+            file: projects/constructive_disagreement/super_sabbatical_wbl/toggle_general_information.md
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/general_information.md
+            conditions:
+              - promptName: toggleGeneralInformation
+                comparator: equals
+                value: "⬇️ Display General Information (Optional Reading)"
       - name: Discussion
         duration: 1800
         discussion:
@@ -230,6 +286,21 @@ treatments:
           showNickname: true
           showTitle: true
         elements:
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/in_round_5min_warning.md
+            displayTime: 1500
+            hideTime: 1740
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/in_round_1min_warning.md
+            displayTime: 1740
+          - type: audio
+            file: shared/counter_bell.mp3
+            displayTime: 1500
+            hideTime: 1505
+          - type: audio
+            file: shared/counter_bell.mp3
+            displayTime: 1740
+            hideTime: 1745
           - type: prompt
             name: inNegotiationNotes
             file: projects/constructive_disagreement/super_sabbatical_wbl/in_nego_notes.md

--- a/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
@@ -425,7 +425,13 @@ treatments:
                 comparator: exists
               - promptName: dealReturnFund
                 comparator: exists
-
+      - name: Transition to Post-Survey
+        elements:
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/maintask_done.md
+          - type: submitButton
+            name: submitDealSheet
+            buttonText: Continue
       - name: General Discussion Survey
         elements:
           - type: prompt

--- a/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
+++ b/projects/constructive_disagreement/super_sabbatical_wbl/super_sabbatical_wbl.treatments.yaml
@@ -222,7 +222,8 @@ treatments:
                 comparator: exists
               - promptName: strategyPlan
                 comparator: exists
-          - projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
+          - type: prompt
+            file: projects/constructive_disagreement/super_sabbatical_wbl/pre_nego_next_page.md
             conditions:
                 - promptName: targetPrice
                   comparator: exists


### PR DESCRIPTION
:white_check_mark: Add drop-down reminders of the materials on the planning page
:white_check_mark: Rewrite the pep talk as a shorter series of bullet points, to save time
:white_check_mark: Removed "Now to negotiate..." as people still have several pages before they actually do the negotiation; it creates confusion.
:white_check_mark: Reduced reading time of Key Things to Remember to 90 seconds (estimated reading time is only 60 seconds).
:white_check_mark: Add note in planning page that this is just for their reference
:white_check_mark: Add note in front of submitting the planning page that the next page will be the negotiation
:white_check_mark: Add 5-minute and 1-minute warning bells

Notes for reference: https://github.com/JamesPHoughton/constructive-disagreement/issues/7#issuecomment-2121082259